### PR TITLE
Update gitignore in order to remove Mandrill API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ nbproject
 .idea
 .node_history
 config/env/.*
+config/mandrillOptions.js


### PR DESCRIPTION
This resolve #1 (partly)